### PR TITLE
added package template

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,8 +15,10 @@ build:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
+      - poetry config virtualenvs.create false
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
+      #- VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
+      - poetry install
       
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,4 +33,4 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "sphinx_material"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,3 +34,20 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # a list of builtin themes.
 #
 html_theme = "sphinx_material"
+
+html_theme_options = {
+    "nav_title": " ",  
+    "base_url": "",  
+    "color_primary": "blue-grey",
+    "color_accent": "cyan",
+    "repo_url": "https://github.com/UBC-MDS/summarease",  
+    "repo_name": "summarease",
+    "repo_type": "github",
+    "globaltoc_depth": 2,  
+    "globaltoc_collapse": True,
+    "globaltoc_includehidden": True,
+}
+html_title = "Summarease Documentation"
+html_sidebars = {
+    "**": ["globaltoc.html", "searchbox.html"],
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,9 +45,9 @@ html_theme_options = {
     "repo_type": "github",
     "globaltoc_depth": 2,  
     "globaltoc_collapse": True,
-    "globaltoc_includehidden": True,
+    "globaltoc_includehidden": True
 }
 html_title = "Summarease Documentation"
 html_sidebars = {
-    "**": ["globaltoc.html", "searchbox.html"],
+    "**": ["globaltoc.html", "localtoc.html", "searchbox.html", "sourcelink.html"],
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,6 @@
 
 ```{toctree}
 :maxdepth: 1
-:hidden:
 :caption: Tutorial
 
 summarize_dtypes.ipynb
@@ -15,7 +14,6 @@ summarize.ipynb
 ```{toctree}
 :maxdepth: 1
 :caption: Development Notes
-:hidden:
 
 changelog.md
 contributing.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,19 @@
 ```{toctree}
 :maxdepth: 1
 :hidden:
+:caption: Tutorial
 
-example.ipynb
+summarize_dtypes.ipynb
+summarize_target.ipynb
+summarize_numeric.ipynb
+summarize.ipynb
+```
+
+```{toctree}
+:maxdepth: 1
+:caption: Development Notes
+:hidden:
+
 changelog.md
 contributing.md
 conduct.md

--- a/docs/summarize.ipynb
+++ b/docs/summarize.ipynb
@@ -4,7 +4,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "# Summarize usage\n",
+                "# Summarize\n",
                 "\n",
                 "To use `summarease` in a project:"
             ]

--- a/docs/summarize.ipynb
+++ b/docs/summarize.ipynb
@@ -1,0 +1,45 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Summarize usage\n",
+                "\n",
+                "To use `summarease` in a project:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import summarease\n",
+                "\n",
+                "print(summarease.__version__)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.8.5"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
+}

--- a/docs/summarize_dtypes.ipynb
+++ b/docs/summarize_dtypes.ipynb
@@ -1,0 +1,45 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Summarize_dtype usage\n",
+                "\n",
+                "To use `summarease` in a project:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import summarease\n",
+                "\n",
+                "print(summarease.__version__)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.8.5"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
+}

--- a/docs/summarize_dtypes.ipynb
+++ b/docs/summarize_dtypes.ipynb
@@ -4,7 +4,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "# Summarize_dtype usage\n",
+                "# Summarize_dtype\n",
                 "\n",
                 "To use `summarease` in a project:"
             ]

--- a/docs/summarize_numeric.ipynb
+++ b/docs/summarize_numeric.ipynb
@@ -1,0 +1,45 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Summarize_numeric usage\n",
+                "\n",
+                "To use `summarease` in a project:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import summarease\n",
+                "\n",
+                "print(summarease.__version__)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.8.5"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
+}

--- a/docs/summarize_numeric.ipynb
+++ b/docs/summarize_numeric.ipynb
@@ -4,7 +4,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "# Summarize_numeric usage\n",
+                "# Summarize_numeric\n",
                 "\n",
                 "To use `summarease` in a project:"
             ]

--- a/docs/summarize_target.ipynb
+++ b/docs/summarize_target.ipynb
@@ -4,7 +4,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "# Summarize_target usage\n",
+                "# Summarize_target\n",
                 "\n",
                 "To use `summarease` in a project:"
             ]

--- a/docs/summarize_target.ipynb
+++ b/docs/summarize_target.ipynb
@@ -1,0 +1,45 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Summarize_target usage\n",
+                "\n",
+                "To use `summarease` in a project:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import summarease\n",
+                "\n",
+                "print(summarease.__version__)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.8.5"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
+}


### PR DESCRIPTION
I added 4 ipynb files for our function usage documentation.
The template is built, below is the html overview.
![image](https://github.com/user-attachments/assets/09cb6519-3231-43ef-ba80-3f88de80f43c)
We can finish our own function documentation in the corresponding .ipynb file in doc/
![image](https://github.com/user-attachments/assets/02e7e309-7245-4d12-928a-3dd62cc94a12)

When we render locally, please:
1. Go to repo dictionary,  in Bash:
- `$ poetry add --group dev myst-nb sphinx-autoapi sphinx-rtd-theme`
- `$ pip install sphinx-material`
2. then go to docs/, `make html`
3. go to docs/_build/html, double click index.md
