### PR TITLE
added fetch tags before semantic release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,6 +68,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 
+      - name: Fetch all tags
+        run: git fetch --tags
+        
       - name: Use Python Semantic Release to prepare release
         id: release
         uses: python-semantic-release/python-semantic-release@v8.3.0


### PR DESCRIPTION
There was an issue in cd, it didn't capture the latest version and created a version 0.0.0.
The version in pyproject.toml was automatically changed to 0.0.0, and generated a 0.0.0 tag with 0.0.0 release automatically.

Therefore, I added these two lines.